### PR TITLE
Feature/15/create a cli command to auto generate keys

### DIFF
--- a/generate-key.js
+++ b/generate-key.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const KEY_NAME = 'API_KEY';
+const newKey = crypto.randomBytes(32).toString('hex');
+const envPath = path.resolve(__dirname, '.env');
+let envContent = '';
+if (fs.existsSync(envPath)) {
+  envContent = fs.readFileSync(envPath, 'utf8');
+}
+
+const keyRegex = new RegExp(`^${KEY_NAME}=.*`, 'm');
+
+if (keyRegex.test(envContent)) {
+  envContent = envContent.replace(keyRegex, `${KEY_NAME}=${newKey}`);
+  console.log(`🔄 Updated ${KEY_NAME} in .env`);
+} else {
+  envContent += `\n${KEY_NAME}=${newKey}\n`;
+  console.log(`✅ Added ${KEY_NAME} to .env`);
+}
+
+fs.writeFileSync(envPath, envContent, 'utf8');
+
+console.log(`🔑 New ${KEY_NAME}: ${newKey}`);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "docker:start-dev": "yarn docker:build && yarn docker:up",
     "local:api-gateway": "APP=api-gateway ./run_container.sh",
     "local:cropping": "APP=cropping ./run_container.sh",
-    "local:image-processing": "APP=image-processing ./run_container.sh"
+    "local:image-processing": "APP=image-processing ./run_container.sh",
+    "generate:key": "node generate-key.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.758.0",


### PR DESCRIPTION
This pull request includes changes to add a new script for generating an API key and updating the `package.json` file to include a new script command. The most important changes are:

### New Script for Generating API Key:

* [`generate-key.js`](diffhunk://#diff-4b2967a66188bf7d2ac55d894313d68971ffde501dace04ee1972eed8211da93R1-R25): Added a new script that generates a random API key, updates or adds it to the `.env` file, and logs the new key.

### Update to `package.json`:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32-R33): Added a new script command `generate:key` to run the `generate-key.js` script.